### PR TITLE
Make index.html point to the default localhost

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,7 +258,7 @@
 
     <script type="text/javascript">
 
-        var BACKEND_URL = "http://caleb-dev.eastus.cloudapp.azure.com:4042/"
+        var BACKEND_URL = "http://localhost:4042/"
         var isLoading = false;
 
         var currentSample = null;


### PR DESCRIPTION
The original BACKEND_URL is pointing to an Azure backend. Since some users that clone the repo might first test the code locally, I believe it would be better to have this variable point to localhost instead.